### PR TITLE
Updated jitpack location

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,11 @@ A Simple Audio Recorder View with hold to Record Button and Swipe to Cancel
 
 
 ## Install
-Add this to your project build.gradle
+Add this to your settings.gradle
 ```gradle
-allprojects {
+dependencyResolutionManagement {
     repositories {
+        ...
         maven { url 'https://jitpack.io' }
     }
 }


### PR DESCRIPTION
Adding `maven { url 'https://jitpack.io' }` to build.gradle is not working anymore.  Now, we have to add it to our settings.gradle . So, updated the docs for the same. Now everything is working fine. BTW great work, thanks for this lib 🤝