### PR TITLE
add a null check to solve crash #93

### DIFF
--- a/record-view/src/main/java/com/devlomi/record_view/AnimationHelper.java
+++ b/record-view/src/main/java/com/devlomi/record_view/AnimationHelper.java
@@ -178,8 +178,10 @@ public class AnimationHelper {
 
 
     public void clearAlphaAnimation(boolean hideView) {
-        alphaAnimation.cancel();
-        alphaAnimation.reset();
+        if (alphaAnimation!=null) {
+            alphaAnimation.cancel();
+            alphaAnimation.reset();
+        }
         smallBlinkingMic.clearAnimation();
         if (hideView) {
             smallBlinkingMic.setVisibility(View.GONE);


### PR DESCRIPTION
added a null check so that if the `clearAlphaAnimation` method is called when the `alphaAnimation` property is null, it doesn't try to access methods on the null object.